### PR TITLE
Add RISC-V kernel emulation setup

### DIFF
--- a/common.c
+++ b/common.c
@@ -1,0 +1,64 @@
+#include "common.h"
+
+void putchar(char ch);
+
+void printf(const char *fmt, ...) {
+    va_list vargs;
+    va_start(vargs, fmt);
+
+    while (*fmt) {
+        if (*fmt == '%') {
+            fmt++; // Skip '%'
+            switch (*fmt) { // Read the next character
+                case '\0': // '%' at the end of the format string
+                    putchar('%');
+                    goto end;
+                case '%': // Print '%'
+                    putchar('%');
+                    break;
+                case 's': { // Print a NULL-terminated string.
+                    const char *s = va_arg(vargs, const char *);
+                    while (*s) {
+                        putchar(*s);
+                        s++;
+                    }
+                    break;
+                }
+                case 'd': { // Print an integer in decimal.
+                    int value = va_arg(vargs, int);
+                    unsigned magnitude = value; // https://github.com/nuta/operating-system-in-1000-lines/issues/64
+                    if (value < 0) {
+                        putchar('-');
+                        magnitude = -magnitude;
+                    }
+
+                    unsigned divisor = 1;
+                    while (magnitude / divisor > 9)
+                        divisor *= 10;
+
+                    while (divisor > 0) {
+                        putchar('0' + magnitude / divisor);
+                        magnitude %= divisor;
+                        divisor /= 10;
+                    }
+
+                    break;
+                }
+                case 'x': { // Print an integer in hexadecimal.
+                    unsigned value = va_arg(vargs, unsigned);
+                    for (int i = 7; i >= 0; i--) {
+                        unsigned nibble = (value >> (i * 4)) & 0xf;
+                        putchar("0123456789abcdef"[nibble]);
+                    }
+                }
+            }
+        } else {
+            putchar(*fmt);
+        }
+
+        fmt++;
+    }
+
+end:
+    va_end(vargs);
+}

--- a/common.h
+++ b/common.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#define va_list  __builtin_va_list
+#define va_start __builtin_va_start
+#define va_end   __builtin_va_end
+#define va_arg   __builtin_va_arg
+
+void printf(const char *fmt, ...);

--- a/kernel.c
+++ b/kernel.c
@@ -1,0 +1,29 @@
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef uint32_t size_t;
+
+extern char __bss[], __bss_end[], __stack_top[];
+
+void *memset(void *buf, char c, size_t n) {
+    uint8_t *p = (uint8_t *) buf;
+    while (n--)
+        *p++ = c;
+    return buf;
+}
+
+void kernel_main(void) {
+    memset(__bss, 0, (size_t) __bss_end - (size_t) __bss);
+
+    for (;;);
+}
+
+__attribute__((section(".text.boot")))
+__attribute__((naked))
+void boot(void) {
+    __asm__ __volatile__(
+        "mv sp, %[stack_top]\n" // Set the stack pointer
+        "j kernel_main\n"       // Jump to the kernel main function
+        :
+        : [stack_top] "r" (__stack_top) // Pass the stack top address as %[stack_top]
+    );
+}

--- a/kernel.c
+++ b/kernel.c
@@ -2,6 +2,8 @@ typedef unsigned char uint8_t;
 typedef unsigned int uint32_t;
 typedef uint32_t size_t;
 
+#include "kernel.h"
+
 extern char __bss[], __bss_end[], __stack_top[];
 
 void *memset(void *buf, char c, size_t n) {
@@ -11,10 +13,38 @@ void *memset(void *buf, char c, size_t n) {
     return buf;
 }
 
-void kernel_main(void) {
-    memset(__bss, 0, (size_t) __bss_end - (size_t) __bss);
+struct sbiret sbi_call(long arg0, long arg1, long arg2, long arg3, long arg4,
+    long arg5, long fid, long eid) {
+register long a0 __asm__("a0") = arg0;
+register long a1 __asm__("a1") = arg1;
+register long a2 __asm__("a2") = arg2;
+register long a3 __asm__("a3") = arg3;
+register long a4 __asm__("a4") = arg4;
+register long a5 __asm__("a5") = arg5;
+register long a6 __asm__("a6") = fid;
+register long a7 __asm__("a7") = eid;
 
-    for (;;);
+__asm__ __volatile__("ecall"
+      : "=r"(a0), "=r"(a1)
+      : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(a4), "r"(a5),
+        "r"(a6), "r"(a7)
+      : "memory");
+return (struct sbiret){.error = a0, .value = a1};
+}
+
+void putchar(char ch) {
+sbi_call(ch, 0, 0, 0, 0, 0, 0, 1 /* Console Putchar */);
+}
+
+void kernel_main(void) {
+    const char *s = "\n\nHello World!\n";
+    for (int i = 0; s[i] != '\0'; i++) {
+    putchar(s[i]);
+    }
+
+    for (;;) {
+    __asm__ __volatile__("wfi");
+    }
 }
 
 __attribute__((section(".text.boot")))

--- a/kernel.c
+++ b/kernel.c
@@ -3,6 +3,7 @@ typedef unsigned int uint32_t;
 typedef uint32_t size_t;
 
 #include "kernel.h"
+#include "common.h"
 
 extern char __bss[], __bss_end[], __stack_top[];
 
@@ -37,10 +38,8 @@ sbi_call(ch, 0, 0, 0, 0, 0, 0, 1 /* Console Putchar */);
 }
 
 void kernel_main(void) {
-    const char *s = "\n\nHello World!\n";
-    for (int i = 0; s[i] != '\0'; i++) {
-    putchar(s[i]);
-    }
+    printf("\n\nHello %s\n", "World!");
+    printf("1 + 2 = %d, %x\n", 1 + 2, 0x1234abcd);
 
     for (;;) {
     __asm__ __volatile__("wfi");

--- a/kernel.h
+++ b/kernel.h
@@ -1,0 +1,6 @@
+#pragma once
+
+struct sbiret {
+    long error;
+    long value;
+};

--- a/kernel.ld
+++ b/kernel.ld
@@ -1,0 +1,28 @@
+ENTRY(boot)
+
+SECTIONS {
+    . = 0x80200000;
+
+    .text :{
+        KEEP(*(.text.boot));
+        *(.text .text.*);
+    }
+
+    .rodata : ALIGN(4) {
+        *(.rodata .rodata.*);
+    }
+
+    .data : ALIGN(4) {
+        *(.data .data.*);
+    }
+
+    .bss : ALIGN(4) {
+        __bss = .;
+        *(.bss .bss.* .sbss .sbss.*);
+        __bss_end = .;
+    }
+
+    . = ALIGN(4);
+    . += 128 * 1024; /* 128KB */
+    __stack_top = .;
+}

--- a/min-kernel.c
+++ b/min-kernel.c
@@ -1,0 +1,29 @@
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef uint32_t size_t;
+
+extern char __bss[], __bss_end[], __stack_top[];
+
+void *memset(void *buf, char c, size_t n) {
+    uint8_t *p = (uint8_t *) buf;
+    while (n--)
+        *p++ = c;
+    return buf;
+}
+
+void kernel_main(void) {
+    memset(__bss, 0, (size_t) __bss_end - (size_t) __bss);
+
+    for (;;);
+}
+
+__attribute__((section(".text.boot")))
+__attribute__((naked))
+void boot(void) {
+    __asm__ __volatile__(
+        "mv sp, %[stack_top]\n" // Set the stack pointer
+        "j kernel_main\n"       // Jump to the kernel main function
+        :
+        : [stack_top] "r" (__stack_top) // Pass the stack top address as %[stack_top]
+    );
+}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -xue
+
+# QEMU file path
+QEMU=qemu-system-riscv32
+
+# Start QEMU
+$QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ CFLAGS="-std=c11 -O2 -g3 -Wall -Wextra --target=riscv32-unknown-elf -fno-stack-p
 
 # Build the kernel
 $CC $CFLAGS -Wl,-Tkernel.ld -Wl,-Map=kernel.map -o kernel.elf \
-    kernel.c
+    kernel.c common.c
 
 # Start QEMU
 $QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \

--- a/run.sh
+++ b/run.sh
@@ -4,5 +4,14 @@ set -xue
 # QEMU file path
 QEMU=qemu-system-riscv32
 
+# Path to clang and compiler flags
+CC=/opt/homebrew/opt/llvm/bin/clang  # Ubuntu users: use CC=clang
+CFLAGS="-std=c11 -O2 -g3 -Wall -Wextra --target=riscv32-unknown-elf -fno-stack-protector -ffreestanding -nostdlib"
+
+# Build the kernel
+$CC $CFLAGS -Wl,-Tkernel.ld -Wl,-Map=kernel.map -o kernel.elf \
+    kernel.c
+
 # Start QEMU
-$QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot
+$QEMU -machine virt -bios default -nographic -serial mon:stdio --no-reboot \
+    -kernel kernel.elf

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ set -xue
 QEMU=qemu-system-riscv32
 
 # Path to clang and compiler flags
-CC=/opt/homebrew/opt/llvm/bin/clang  # Ubuntu users: use CC=clang
+CC=clang  # non-Ubuntu users: use CC=/opt/homebrew/opt/llvm/bin/clang
 CFLAGS="-std=c11 -O2 -g3 -Wall -Wextra --target=riscv32-unknown-elf -fno-stack-protector -ffreestanding -nostdlib"
 
 # Build the kernel


### PR DESCRIPTION
Introduce a script to start QEMU for RISC-V emulation, a linker script for kernel memory layout, and implement basic kernel functionality including memory initialization and boot entry point. Enhance the script to build the kernel and load it into QEMU.